### PR TITLE
requests 재귀할떄만 3초 쉬기 + dcinside 봇 차단 헤더 설정

### DIFF
--- a/crawling/src/crawling_tool.py
+++ b/crawling/src/crawling_tool.py
@@ -22,7 +22,7 @@ def get_new_row_from_main_content(url_row):
         content = url_row['title'] + " " + content
         new_row = [url_row['date'], url_row['title'], url_row['url'], url_row['media'], content, is_comment]
     except Exception as e:
-        print("[오류가 발생하여 반복합니다] ", e)
+        print("[오류가 발생하여 반복합니다] [get_new_row_from_main_content()] ", e)
         new_row = get_new_row_from_main_content(url_row)
     return new_row
 
@@ -38,7 +38,7 @@ def get_reply_list(url):
         reply_list = soup.find_all("li", {"class": "ub-content"})
         driver.quit()
     except Exception as e:
-        print("[오류가 발생하여 반복합니다] ", e)
+        print("[오류가 발생하여 반복합니다] [get_reply_list()] ", e)
         reply_list = get_reply_list(url)
     return reply_list
 
@@ -124,9 +124,10 @@ def get_url_base(gall_url):
 # 기능 : 검색결과 중 가장 큰 글번호를 구하여 리턴한다
 # 리턴값 : max_num
 def get_max_num(keyword, gall_id, url_base):
-    search_url = f"{url_base}/board/lists/?id={gall_id}&s_type=search_subject_memo&s_keyword={keyword}"
+    temp_url = f"{url_base}/board/lists/?id={gall_id}&s_type=search_subject_memo&s_keyword={keyword}"
+    print("temp_url = ", temp_url)
     with requests.Session() as session:
-        response = session.get(search_url, headers=header)
+        response = session.get(temp_url, headers=header)
     soup = BeautifulSoup(response.text, "html.parser")  # 페이지의 soup
     box = soup.select("div.gall_listwrap tr.ub-content")        # 글만 있는 box
     first_content = ''
@@ -161,6 +162,6 @@ def get_last_page(url):
         else:
             last_page = num_button_count
     except Exception as e:
-        print("[오류가 발생하여 반복합니다] ", e)
+        print("[오류가 발생하여 반복합니다] [get_last_page()] ", e)
         last_page = get_last_page(url)
     return last_page

--- a/crawling/src/crawling_tool.py
+++ b/crawling/src/crawling_tool.py
@@ -6,10 +6,38 @@ from selenium import webdriver
 import datetime
 import utility_module as util
 
-header = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36"
+# dcinside 봇 차단을 위한 헤더 설정
+header_dc = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36",
+        "Connection" : "keep-alive",
+        "Cache-Control" : "max-age=0",
+        "sec-ch-ua-mobile" : "?0",
+        "DNT" : "1",
+        "Upgrade-Insecure-Requests" : "1",
+        "Accept" : "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+        "Sec-Fetch-Site" : "none",
+        "Sec-Fetch-Mode" : "navigate",
+        "Sec-Fetch-User" : "?1",
+        "Sec-Fetch-Dest" : "document",
+        "Accept-Encoding" : "gzip, deflate, br",
+        "Accept-Language" : "ko-KR,ko;q=0.9"
     }
 
+
+###############################
+# get_search_result()
+# 기능 : 검색결과 페이지 정보를 불러온다
+# 리턴값 : 검색결과의 글 리스트
+def get_search_result(search_url, time_sleep_sec=0):
+    try:
+        with requests.Session() as session:
+            response = session.get(search_url, headers=header_dc)
+        soup = BeautifulSoup(response.text, "html.parser")  # 검색 결과 페이지
+        element_list = soup.select("table.gall_list tr.ub-content")  # 한 페이지 전체 글 리스트
+    except Exception as e:
+        print("[오류가 발생하여 반복합니다] [get_search_result()] ", e)
+        element_list = get_search_result(search_url, 3)
+    return element_list
 
 ###############################
 # get_max_num()
@@ -20,7 +48,7 @@ def get_max_num(keyword, gall_id, url_base, time_sleep_sec=0):
         temp_url = f"{url_base}/board/lists/?id={gall_id}&s_type=search_subject_memo&s_keyword={keyword}"
         print("temp_url = ", temp_url)
         with requests.Session() as session:
-            response = session.get(temp_url, headers=header)
+            response = session.get(temp_url, headers=header_dc)
             time.sleep(time_sleep_sec)
         soup = BeautifulSoup(response.text, "html.parser")  # 페이지의 soup
         box = soup.select("div.gall_listwrap tr.ub-content")        # 글만 있는 box
@@ -46,7 +74,7 @@ def get_new_row_from_main_content(url_row, time_sleep_sec=0):
     is_comment = 0  # 본문이므로 0
     try:
         with requests.Session() as session:
-            response = session.get(url_row['url'], headers=header)
+            response = session.get(url_row['url'], headers=header_dc)
             time.sleep(time_sleep_sec)
         soup = BeautifulSoup(response.text, "html.parser")
         content = util.preprocess_content_dc(soup.find('div', {"class": "write_div"}).text)
@@ -82,7 +110,7 @@ def get_reply_list(url, time_sleep_sec=0):
 def get_last_page(url, time_sleep_sec=0):
     try:
         with requests.Session() as session:
-            response = session.get(url, headers=header)
+            response = session.get(url, headers=header_dc)
             time.sleep(time_sleep_sec)
         soup = BeautifulSoup(response.text, "html.parser").find("div", class_="bottom_paging_wrap re")
         filtered_a_tags = [a for a in soup.find_all('a') if not a.find('span', class_='sp_pagingicon')]

--- a/crawling/src/crawling_tool.py
+++ b/crawling/src/crawling_tool.py
@@ -1,4 +1,5 @@
 import re
+import time
 import requests
 from bs4 import BeautifulSoup
 from selenium import webdriver
@@ -147,10 +148,11 @@ def get_max_num(keyword, gall_id, url_base):
 # get_last_page()
 # 기능 : [dcinside] 갤러리 내에서 검색결과의 마지막 페이지가 몇인지 리턴 (검색한 직후의 url이어야 함)
 # 리턴값 : max_page(int)
-def get_last_page(url):
+def get_last_page(url, time_sleep_sec=0):
     try:
         with requests.Session() as session:
             response = session.get(url, headers=header)
+            time.sleep(time_sleep_sec)
         soup = BeautifulSoup(response.text, "html.parser").find("div", class_="bottom_paging_wrap re")
         filtered_a_tags = [a for a in soup.find_all('a') if not a.find('span', class_='sp_pagingicon')]
         num_button_count = len(filtered_a_tags) + 1    # 숫자 버튼의 개수
@@ -163,5 +165,5 @@ def get_last_page(url):
             last_page = num_button_count
     except Exception as e:
         print("[오류가 발생하여 반복합니다] [get_last_page()] ", e)
-        last_page = get_last_page(url)
+        last_page = get_last_page(url, 1)
     return last_page

--- a/crawling/src/crawling_tool.py
+++ b/crawling/src/crawling_tool.py
@@ -13,34 +13,36 @@ header = {
 
 #####################################
 # 본문에서 new_row를 얻어오는 함수
-def get_new_row_from_main_content(url_row):
+def get_new_row_from_main_content(url_row, time_sleep_sec=0):
     is_comment = 0  # 본문이므로 0
     try:
         with requests.Session() as session:
             response = session.get(url_row['url'], headers=header)
+            time.sleep(time_sleep_sec)
         soup = BeautifulSoup(response.text, "html.parser")
         content = util.preprocess_content_dc(soup.find('div', {"class": "write_div"}).text)
         content = url_row['title'] + " " + content
         new_row = [url_row['date'], url_row['title'], url_row['url'], url_row['media'], content, is_comment]
     except Exception as e:
         print("[오류가 발생하여 반복합니다] [get_new_row_from_main_content()] ", e)
-        new_row = get_new_row_from_main_content(url_row)
+        new_row = get_new_row_from_main_content(url_row, 1)
     return new_row
 
 
 #####################################
 # 기능 : url을 받아 reply_list를 리턴합니다
 # 리턴값 : reply_list
-def get_reply_list(url):
+def get_reply_list(url, time_sleep_sec=0):
     try:
         driver = get_driver()
         driver.get(url)
+        time.sleep(time_sleep_sec)
         soup = BeautifulSoup(driver.page_source, "html.parser")
         reply_list = soup.find_all("li", {"class": "ub-content"})
         driver.quit()
     except Exception as e:
         print("[오류가 발생하여 반복합니다] [get_reply_list()] ", e)
-        reply_list = get_reply_list(url)
+        reply_list = get_reply_list(url, 1)
     return reply_list
 
 

--- a/crawling/src/dcinside_crawler.py
+++ b/crawling/src/dcinside_crawler.py
@@ -180,6 +180,7 @@ def get_content_dc(gall_url, keyword):
     # 4) 끝나면 파일로 저장, 에러 로그 체크
     # 4-a) 결과 csv 파일로 저장
     try:
+        print(f"[{len(data_list)}개의 url 정보가 저장되었습니다]")
         df_result = pd.DataFrame(data_list, columns=['date', 'title', 'url', 'media', 'content', 'is_comment'])
         util.save_file(df_result, content_folder_path, f"{content_file_name}.csv")
     except Exception as e:

--- a/crawling/src/dcinside_crawler.py
+++ b/crawling/src/dcinside_crawler.py
@@ -27,11 +27,11 @@ def get_url_dc(gall_url, keyword):
     try:
         keyword_unicode = util.convert_to_unicode(keyword)          # 입력받은 키워드를 유니코드로 변환한다
         gall_id = cr.get_gall_id(gall_url)                   # 갤러리 id
+        print("gall_id : ", gall_id)
         url_base = cr.get_url_base(gall_url)                 # "https" 부터 "board/" 이전까지의 url 부분 (major갤, minor갤, mini갤)
-        max_num = cr.get_max_num(keyword, gall_id, url_base)   # 검색결과 중, 가장 큰 글번호 10000단위로 올림한 값/10000
-        print(url_base)
-        print(gall_id)
-        print(max_num)
+        print("url_base : ", url_base)
+        max_num = cr.get_max_num(keyword_unicode, gall_id, url_base)   # 검색결과 중, 가장 큰 글번호 10000단위로 올림한 값/10000
+        print("max_num : ", max_num)
         folder_path = f"./url/{gall_id}"        # 저장할 폴더 경로 설정
         util.create_folder(folder_path)         # 폴더 만들기
         error_log = []                          # 에러 로그 저장

--- a/crawling/src/dcinside_crawler.py
+++ b/crawling/src/dcinside_crawler.py
@@ -7,12 +7,6 @@ from bs4 import BeautifulSoup
 import crawling_tool as cr
 import utility_module as util
 import pandas as pd
-import requests
-
-
-header = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36"
-    }
 
 
 ##############################################
@@ -52,20 +46,11 @@ def get_url_dc(gall_url, keyword):
         last_page = cr.get_last_page(temp_url)     # 1만 단위 검색결과의 마지막 페이지
         # 해외주식갤러리처럼 컨텐츠 많을때, 1,2,3,4,5 이렇게 페이징 되어있는거 있음. 이걸 페이지 넘기면서 크롤링
         for page in range(1, last_page+1):
-            try:
-                # [검색결과 페이지 불러오기]
-                print(f"[크롤링 시작][search_pos : {search_pos}][page : {page}/{last_page}]")
-                search_url = f"{url_base}/board/lists/?id={gall_id}&page={page}&search_pos=-{search_pos}&s_type=search_subject_memo&s_keyword={keyword_unicode}"
-                with requests.Session() as session:
-                    response = session.get(search_url, headers=header)
-                soup = BeautifulSoup(response.text, "html.parser")      # 검색 결과 페이지
-                element_list = soup.select("table.gall_list tr.ub-content")     # 한 페이지 전체 글 리스트
-                print(f"[글 개수 : {len(element_list)}]")
-            except Exception as e:
-                status = "[검색결과 페이지 불러오기]"
-                print(f'[error]{status}[error message : {e}]')
-                error_log.append([search_url, status, e])
-                continue
+            # [검색결과 페이지 불러오기]
+            print(f"[크롤링 시작][search_pos : {search_pos}][page : {page}/{last_page}]")
+            search_url = f"{url_base}/board/lists/?id={gall_id}&page={page}&search_pos=-{search_pos}&s_type=search_subject_memo&s_keyword={keyword_unicode}"
+            element_list = cr.get_search_result(search_url)
+            print(f"[글 개수 : {len(element_list)}]")
             # 글 하나씩 뽑아서 크롤링
             for element in element_list:    # element == 글 하나
                 try:

--- a/crawling/src/dcinside_crawler.py
+++ b/crawling/src/dcinside_crawler.py
@@ -87,6 +87,7 @@ def get_url_dc(gall_url, keyword):
 
     # 2. 파일로 저장
     try:
+        print(f"[{len(data_list)}개의 url 정보가 저장되었습니다]")
         df_result = pd.DataFrame(data_list, columns=['date', 'title', 'url', 'media'])
         util.save_file(df_result, folder_path, f"{file_name}.csv")
     except Exception as e:

--- a/crawling/tests/test_dcinside.py
+++ b/crawling/tests/test_dcinside.py
@@ -7,7 +7,7 @@
 from dcinside_crawler import get_url_dc, get_content_dc
 
 # 설정값
-keyword = "에스엠"
+keyword = "에코"
 gall_name = "코스피"
 # blacklist = ["토스트", "도리토스", "치토스", "멘토스", "셀토스", "키보토스", "프로토스", "테스토스테론"]
 gall_url = {

--- a/crawling/tests/test_dcinside.py
+++ b/crawling/tests/test_dcinside.py
@@ -7,8 +7,8 @@
 from dcinside_crawler import get_url_dc, get_content_dc
 
 # 설정값
-keyword = "에코프로"
-gall_name = "해외주식"
+keyword = "에스엠"
+gall_name = "코스피"
 # blacklist = ["토스트", "도리토스", "치토스", "멘토스", "셀토스", "키보토스", "프로토스", "테스토스테론"]
 gall_url = {
     "미국주식": "https://gall.dcinside.com/mgallery/board/lists?id=stockus",
@@ -25,7 +25,7 @@ gall_url = {
 
 
 # [1. url 크롤링]
-# get_url_dc(gall_url[gall_name], keyword)
+get_url_dc(gall_url[gall_name], keyword)
 
 # [2. content 크롤링]
-get_content_dc(gall_url[gall_name], keyword)
+# get_content_dc(gall_url[gall_name], keyword)

--- a/crawling/tests/test_dcinside.py
+++ b/crawling/tests/test_dcinside.py
@@ -7,7 +7,7 @@
 from dcinside_crawler import get_url_dc, get_content_dc
 
 # 설정값
-keyword = "에코"
+keyword = "에스엠"
 gall_name = "코스피"
 # blacklist = ["토스트", "도리토스", "치토스", "멘토스", "셀토스", "키보토스", "프로토스", "테스토스테론"]
 gall_url = {
@@ -25,7 +25,7 @@ gall_url = {
 
 
 # [1. url 크롤링]
-get_url_dc(gall_url[gall_name], keyword)
+# get_url_dc(gall_url[gall_name], keyword)
 
 # [2. content 크롤링]
-# get_content_dc(gall_url[gall_name], keyword)
+get_content_dc(gall_url[gall_name], keyword)

--- a/utility_module.py
+++ b/utility_module.py
@@ -103,7 +103,7 @@ def error_check(error_log, folder_path, file_name):
         df_error = pd.DataFrame(error_log)   # df 생성
         error_file_path = os.path.join(folder_path, f"{file_name}_error.csv")
         df_error.to_csv(error_file_path, encoding='utf-8', index=False)
-        print("[에러 발생 로그를 파일로 저장함]")
+        print(f"[총 {len(error_log)}개의 에러 로그가 파일로 저장되었습니다]")
     else:
         print("[에러 없음]")
 


### PR DESCRIPTION
- 어느 부분에서 에러가 났는지 알 수 있도록 디버그 출력 문구를 변경했습니다
- 크롤링된 data_list의 길이, error_log의 길이를 출력하여 사용자가 바로 인지할 수 있도록 합니다
- requests를 사용하기 때문에, 오류처리 후 재귀시 time.sleep(3)으로 쉬어준다
- dcinside 봇 차단을 위해 header 설정을 추가했다
- dcinside_crawler.py의 requests이용한 코드를 전부 crawling_tool.py에 함수화하여, crawling_tool.py에만 header 설정을 해도 되도록 변경하였다. (코드 중복 없앰)